### PR TITLE
Cloud-Init triggered install/start of docker will always hang

### DIFF
--- a/docker-storage-setup.service
+++ b/docker-storage-setup.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Docker Storage Setup
-After=cloud-final.service
 Before=docker.service
 
 [Service]


### PR DESCRIPTION
Removes cloud-init dependency from the service to avoid hangs.

Fixes #77
