### PR TITLE
Allow the LV to be set to error when full

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -71,6 +71,11 @@ CHUNK_SIZE:
       Controls the chunk size/block size of thin pool. Value of CHUNK_SIZE
       be suitable to be passed to --chunk-size option of lvconvert.
 
+LV_ERROR_WHEN_FULL
+      Controls the LV behavior when full. Default behavior is controlled by
+      lvm.conf. Setting LV_ERROR_WHEN_FULL=yes forces the LV to error when
+      writes are attempted rather than queuing.
+
 The options below should be specified as values acceptable to 'lvextend -L':
 
 ROOT_SIZE: The size to which the root filesystem should be grown.

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -66,3 +66,7 @@ POOL_AUTOEXTEND_THRESHOLD=60
 
 # Extend the pool by specified percentage when threshold is hit.
 POOL_AUTOEXTEND_PERCENT=20
+
+# Error when full instead of queue. Defaults to "no", change to "yes" to
+# enable.
+# LV_ERROR_WHEN_FULL=yes

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -303,6 +303,12 @@ create_lvm_thin_pool () {
   lvconvert -y --zero n $CHUNK_SIZE_ARG --thinpool $VG/$DATA_LV_NAME --poolmetadata $VG/$META_LV_NAME
 }
 
+configure_lvm_thin_pool() {
+  if [[ "${LV_ERROR_WHEN_FULL}" == "yes" ]]; then
+    lvchange --errorwhenfull y "${VG}/${DATA_LV_NAME}"
+  fi
+}
+
 setup_lvm_thin_pool () {
   # At this point of time, a volume group should exist for lvm thin pool
   # operations to succeed. Make that check and fail if that's not the case.
@@ -312,6 +318,7 @@ setup_lvm_thin_pool () {
 
   if ! lvm_pool_exists; then
     create_lvm_thin_pool
+    configure_lvm_thin_pool
     write_storage_config_file
   fi
 


### PR DESCRIPTION
Related to #103, setting the `lv_when_full` behavior to `error` and pre-allocating the LV to use the whole VG seems to have better behavior when the VG is not used for other LVs.
