### PR TITLE
Fix problems on update F22->F24

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -398,7 +398,7 @@ reset_lvm_thin_pool () {
 }
 
 setup_lvm_thin_pool () {
-  local tpool
+  local tpool lv_name
 
   # Check if a thin pool is already configured in /etc/sysconfig/docker-storage.
   # If yes, wait for that thin pool to come up.
@@ -408,6 +408,12 @@ setup_lvm_thin_pool () {
      Info "Found an already configured thin pool $tpool in ${DOCKER_STORAGE}"
      if ! wait_for_dev "$tpool"; then
        Fatal "Already configured thin pool $tpool is not available. If thin pool exists and is taking longer to activate, set DEVICE_WAIT_TIMEOUT to a higher value and retry. If thin pool does not exist any more, remove ${DOCKER_STORAGE} and retry"
+     fi
+     lv_name=${tpool#/dev/mapper/}
+     lv_name=${lv_name#${VG}-}
+     if [[ -n "$lv_name" && x"$lv_name" != x"$POOL_LV_NAME" ]]; then
+         Info "overriding default Pool name: $lv_name"
+         POOL_LV_NAME=$lv_name
      fi
   fi
 

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -373,6 +373,10 @@ get_configured_thin_pool() {
   for opt in $options; do
     if [[ $opt =~ dm.thinpooldev* ]];then
       tpool=${opt#*=}
+      case "$tpool" in
+      /dev/mapper/*) ;;
+      *) tpool="/dev/mapper/$tpool";;
+      esac
       echo "$tpool"
       return 0
     fi


### PR DESCRIPTION
This merge request fixes problems I encountered when updating my system from F22 to F24. I had a DM thinpooldev with a name different from "docker-pool", and I was using the shorthand dm.thinpooldev syntax (which used to be recommended some time ago IIRC). See commits for details.

If docker-storage-setup fails to import a preexisiting storage configuration, it recommends the user to completely delete /var/lib/docker and restart from scratch which is a pretty scary option if you have some productive containers.
