### PR TITLE
Look for default config file and helper exec file in source dir first

### DIFF
--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -118,12 +118,16 @@ should_enable_deferred_deletion() {
 platform_supports_deferred_deletion() {
         local deferred_deletion_supported=1
         trap cleanup_pipes EXIT
-        if [ ! -x "/usr/lib/container-storage-setup/css-child-read-write" ];then
+        local child_exec="$SRCDIR/css-child-read-write.sh"
+
+        [ ! -x "$child_exec" ] && child_exec="/usr/lib/container-storage-setup/css-child-read-write"
+
+        if [ ! -x "$child_exec" ];then
            return 1
         fi
         mkfifo $PIPE1
         mkfifo $PIPE2
-        unshare -m /usr/lib/container-storage-setup/css-child-read-write $PIPE1 $PIPE2 "$TEMPDIR" &
+        unshare -m ${child_exec} $PIPE1 $PIPE2 "$TEMPDIR" &
         read -t 10 n <>$PIPE1
         if [ "$n" != "start" ];then
 	   return 1
@@ -1186,7 +1190,9 @@ elif [ -e /usr/lib/container-storage-setup/libcss.sh ]; then
   source /usr/lib/container-storage-setup/libcss.sh
 fi
 
-if [ -e /usr/lib/container-storage-setup/container-storage-setup ]; then
+if [ -e $SRCDIR/container-storage-setup.conf ]; then
+  source $SRCDIR/container-storage-setup.conf
+elif [ -e /usr/lib/container-storage-setup/container-storage-setup ]; then
   source /usr/lib/container-storage-setup/container-storage-setup
 fi
 


### PR DESCRIPTION
We put all defaults in container-storage-setup.conf and look for this
file in /usr/lib/container-storage-setup. Instead first look for this
file in source dir where container-storage-setup is present and if not
found look in /usr/lib/

It solves one main problem that is one does not have to do "make install"
to test the code. Everything needed is available in source code itself.

It also helps if during code development, if one introduces a new default
variable, then without doing "make install" one can test their code.

During migration from docker-storage-setup to container-storage-setup also
it continues to work. Otherwise without this change, script can't find
container-storage-setup.conf in /usr/lib/container-storage-setup/ and
breaks down.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>