### PR TITLE
Use findmnt option --target instead of --mountpoint

### DIFF
--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -903,7 +903,7 @@ extra_lv_mountpoint() {
   local mounts
   local lv_name=$1
   local mount_dir=$2
-  mounts=$(findmnt -n -o TARGET --source /dev/$VG/$lv_name --mountpoint $mount_dir | head -1)
+  mounts=$(findmnt -n -o TARGET --source /dev/$VG/$lv_name | grep $mount_dir)
   echo $mounts
 }
 


### PR DESCRIPTION
Old findmnt utility (on rhel/centos) does not support new option --mountpoint
and tests fail there.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>