### PR TITLE
Use DOCKER_STORAGE_OPTIONS in output only in compatibility mode

### DIFF
--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -1227,7 +1227,7 @@ case $# in
 	;;
 esac
 
-if [ "${_STORAGE_OUT_FILE}" = "/etc/sysconfig/docker-storage" ]; then
+if [ -n "$_DOCKER_COMPAT_MODE" ]; then
    _STORAGE_OPTIONS="DOCKER_STORAGE_OPTIONS"
 fi
 


### PR DESCRIPTION
In generic mode, it will output STORAGE_OPTIONS. At some point of time
we should probably provide another config knob to make this prefix
configurable so that docker can make use of new generic mode and
not be limited to only compatibility mode.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>