### PR TITLE
Bump up version to 0.2.0

### DIFF
--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -23,7 +23,7 @@ set -e
 
 # container-storage-setup version information
 _CSS_MAJOR_VERSION="0"
-_CSS_MINOR_VERSION="1"
+_CSS_MINOR_VERSION="2"
 _CSS_SUBLEVEL="0"
 _CSS_EXTRA_VERSION=""
 


### PR DESCRIPTION
Enough changes have gone in since 0.1.0 that it is time to bump up
version.

Again, backward comaptibility will be provided only for docker
compatibility mode. For new functionality, backward compatibility
will be maintained only after release 1.0.0

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>