### PR TITLE
Suggest usage of /var/lib/containers/storage

### DIFF
--- a/container-storage-setup.1
+++ b/container-storage-setup.1
@@ -136,9 +136,9 @@ CONTAINER_ROOT_LV_MOUNT_PATH:
      Creates a logical volume named CONTAINER_ROOT_LV_NAME and mounts
      it at the specified path. By default no new logical volume will
      be created. For example:
-     \f[B]CONTAINER_ROOT_LV_MOUNT_PATH=/var/lib/containers\f[]
+     \f[B]CONTAINER_ROOT_LV_MOUNT_PATH=/var/lib/containers/container-runtime\f[]
      would carve out a logical volume, format it with an XFS filesystem
-     and mount it on /var/lib/containers.
+     and mount it on /var/lib/containers/container-runtime.
 
      Note: DOCKER_ROOT_VOLUME is deprecated. Specifying
      DOCKER_ROOT_VOLUME and CONTAINER_ROOT_LV_MOUNT_PATH at the same

--- a/container-storage-setup.conf
+++ b/container-storage-setup.conf
@@ -117,7 +117,7 @@ CONTAINER_ROOT_LV_SIZE=40%FREE
 
 # Creates a logical volume named $CONTAINER_ROOT_LV_NAME and mount it on
 # $CONTAINER_ROOT_LV_MOUNT_PATH. By default no new logical volume will
-# be created. e.g. Specifying CONTAINER_ROOT_LV_MOUNT_PATH=/var/lib/containers
+# be created. e.g. Specifying CONTAINER_ROOT_LV_MOUNT_PATH=/var/lib/containers/container-runtime
 # will carve out a logical volume, create a filesystem on it and mount
-# it on /var/lib/containers.
-# CONTAINER_ROOT_LV_MOUNT_PATH="/var/lib/containers"
+# it on /var/lib/containers/container-runtime.
+# CONTAINER_ROOT_LV_MOUNT_PATH="/var/lib/containers/container-runtime"


### PR DESCRIPTION
system containers install under /var/lib/containers/atomic and they
need to use the same file system as /ostree/repo so that hard links
from the OSTree repository can be used.  Suggest usage of
/var/lib/containers/storage to avoid this conflict.

Closes: https://github.com/projectatomic/container-storage-setup/issues/231

Change done with:

git ls-files | xargs sed -i -e"s|/var/lib/containers|/var/lib/containers/storage|"

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>