### PR TITLE
Use profile_dir setting used by LVM2 during command execution

### DIFF
--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -910,7 +910,7 @@ enable_auto_pool_extension() {
   local profileDir
   local tmpFile=`mktemp -p /run -t tmp.XXXXX`
 
-  profileDir=$(lvm dumpconfig | grep "profile_dir" | cut -d "=" -f2 | sed 's/"//g')
+  profileDir=$(lvm dumpconfig --type full | grep "profile_dir" | cut -d "=" -f2 | sed 's/"//g')
   [ -n "$profileDir" ] || return 1
 
   if [ ! -n "$POOL_AUTOEXTEND_THRESHOLD" ];then
@@ -941,7 +941,7 @@ disable_auto_pool_extension() {
   local profileFile="${profileName}.profile"
   local profileDir
 
-  profileDir=$(lvm dumpconfig | grep "profile_dir" | cut -d "=" -f2 | sed 's/"//g')
+  profileDir=$(lvm dumpconfig --type full | grep "profile_dir" | cut -d "=" -f2 | sed 's/"//g')
   [ -n "$profileDir" ] || return 1
 
   lvchange --detachprofile ${volume_group}/${pool_volume}


### PR DESCRIPTION
Use profile_dir setting used by LVM2 during command execution
    
"lvm dumpconfig" is currently used to determine profile_dir location.
But if profile_dir is not explicitly defined in /etc/lvm/lvm.conf, then
the default value used by lvm will not be listed.
Hence use "lvm dumpconfig --type full" instead.
    
Signed-off-by: Carson Blake Smith <smith.carson19@gmail.com>