### PR TITLE
Fix sfdisk failure on older sfdisk

### DIFF
--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -821,8 +821,7 @@ create_partition_sfdisk(){
   size=$(( $( awk "\$4 ~ /"$( basename $dev )"/ { print \$3 }" /proc/partitions ) * 2 - 2048 ))
     cat <<EOF | sfdisk $dev
 unit: sectors
-
-start=     2048, size=  ${size}, Id=8e
+2048,${size},8e
 EOF
 }
 


### PR DESCRIPTION
We used to use following input file for sfdisk.

units:sectors
{dev}1: start=2048, size=4096, Id=8e

And this worked both with old and new sfdisk. But this required
hardcoding partition name and we wanted to move away from that
as it did not work for pmem and loop devices. So we started using
following format instead.

units:sectors
start=2048, size=4096, Id=8e

As per latest sfdisk man page this should work but it does not seem to
work with sfdisk shipped with older util-linux (util-linux-2.23.2-33),
and we get errors like following.

sfdisk: trailing junk after number

sfdisk: bad input

But following format seems to work with old sfdisk format. So switch
to using that one.

units:sectors
2048, 4096, 8e

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>