### PR TITLE
Release version 0.6.0

### DIFF
--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -23,7 +23,7 @@ set -e
 
 # container-storage-setup version information
 _CSS_MAJOR_VERSION="0"
-_CSS_MINOR_VERSION="3"
+_CSS_MINOR_VERSION="6"
 _CSS_SUBLEVEL="0"
 _CSS_EXTRA_VERSION=""
 


### PR DESCRIPTION
Bumped version from 0.3.0 to 0.6.0. I realized that in the past we already
released some versions like v0.5. So to avoid conflict with previous versions
bump it to a higher number which has never been released.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>