### PR TITLE
add MAX_DATA_SIZE option

### DIFF
--- a/container-storage-setup.conf
+++ b/container-storage-setup.conf
@@ -59,6 +59,20 @@ DATA_SIZE=40%FREE
 #
 MIN_DATA_SIZE=2G
 
+# MAX_DATA_SIZE specifies the maximum size of data volume otherwise pool
+# creation fails.
+#
+# Value should be a number followed by a optional suffix. "bBsSkKmMgGtTpPeE"
+# are valid suffixes. If no suffix is specified then value will be considered
+# as mebibyte unit.
+#
+# Both upper and lower case suffix represent same unit of size. Use suffix B
+# for Bytes, S for sectors as 512 bytes, K for kibibytes (1024 bytes), M for
+# mebibytes (1024 kibibytes), G for gibibytes, T for tebibytes, P for
+# pebibytes and E for exbibytes.
+#
+#MAX_DATA_SIZE=2G
+
 # Controls the chunk size/block size of thin pool. Value of CHUNK_SIZE
 # be suitable to be passed to --chunk-size option of lvconvert.
 #


### PR DESCRIPTION
Some sever have a large disk like 2T, but only need at most 200G for docker to store images and containers. 
And then create logical volume  with rest free space as host path volume to be used with  -v option in docker run command .
Add new MAX_DATA_SIZE option may be simpler than calculating DATA_SIZE for every SERVER.