### PR TITLE
ci:  rename files to new name and bump to f26

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -4,11 +4,11 @@ branches:
   - try
 
 host:
-  distro: fedora/25/atomic
+  distro: fedora/26/atomic
   specs:
     secondary-disk: 10
 
-context: fedora/25/atomic
+context: fedora/26/atomic
 
 required: true
 

--- a/.papr.yml
+++ b/.papr.yml
@@ -14,7 +14,8 @@ required: true
 
 tests:
   - systemctl stop docker
-  - rm -rf /var/lib/docker
+  # just empty the dir, don't delete it (on F26, /var/lib/docker is an lv mount)
+  - rm -rf /var/lib/docker/*
   - ostree admin unlock
   - make install
   - rm -f /etc/sysconfig/docker-storage-setup


### PR DESCRIPTION
Rename the YAML file and its auxiliary files to the newly supported
name. Bump tests to use f26.