### PR TITLE
Add SELinux information for setting labels on mount points

### DIFF
--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -23,7 +23,7 @@ set -e
 
 # container-storage-setup version information
 _CSS_MAJOR_VERSION="0"
-_CSS_MINOR_VERSION="6"
+_CSS_MINOR_VERSION="7"
 _CSS_SUBLEVEL="0"
 _CSS_EXTRA_VERSION=""
 


### PR DESCRIPTION
If you setup a container-storage-setup to mount a new volume at
a storage mount point, the administrator will need to set the SELinux
labels by running `restorecon -R MOUNTPOINT`

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>