### PR TITLE
Add a knob POOL_META_SIZE

### DIFF
--- a/container-storage-setup.1
+++ b/container-storage-setup.1
@@ -234,6 +234,19 @@ MIN_DATA_SIZE: Specifies the minimum size of the thin pool data LV. If
 	kibibytes (1024 bytes), M for mebibytes (1024 kibibytes), G for
 	gibibytes, T for tebibytes, P for pebibytes and E for exbibytes.
 
+POOL_META_SIZE: Specifies the size of thin pool metadata LV. If
+	sufficient free space is not available, the pool creation will
+	fail.
+
+	Value should be a number followed by a optional suffix.
+	"bBsSkKmMgGtTpPeE" are valid suffixes. If no suffix is specified
+	then value will be considered as megabyte unit.
+
+	Both upper and lower case suffix represent same unit of size.
+	Use suffix B for Bytes, S for sectors as 512 bytes, K for
+	kibibytes (1024 bytes), M for mebibytes (1024 kibibytes), G for
+	gibibytes, T for tebibytes, P for pebibytes and E for exbibytes.
+
 \f[B]Sample\f[]
 
 A simple, sample INPUTFILE:

--- a/container-storage-setup.conf
+++ b/container-storage-setup.conf
@@ -59,6 +59,20 @@ DATA_SIZE=40%FREE
 #
 MIN_DATA_SIZE=2G
 
+# The desired size for the thin pool metadata volume.  Defaults to using .1%
+# of FREE space in Volume Group.
+#
+# Values passed should be suitable to be used by --poolmetadatasize option
+# of lvcreate. It should be a number followed by a optional suffix.
+# "bBsSkKmMgGtTpPeE" are valid suffixes. If no suffix is specified then value
+# will be considered as mebibyte unit.
+#
+# Both upper and lower case suffix represent same unit of size. Use suffix B
+# for Bytes, S for sectors as 512 bytes, K for kibibytes (1024 bytes), M for
+# mebibytes (1024 kibibytes), G for gibibytes, T for tebibytes, P for
+# pebibytes and E for exbibytes.
+#POOL_META_SIZE=16M
+
 # Controls the chunk size/block size of thin pool. Value of CHUNK_SIZE
 # be suitable to be passed to --chunk-size option of lvconvert.
 #

--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -377,13 +377,17 @@ create_lvm_thin_pool () {
 
   check_min_data_size_condition
 
+  if [ -n "$POOL_META_SIZE" ]; then
+    _META_SIZE_ARG="$POOL_META_SIZE"
+  else
   # Calculate size of metadata lv. Reserve 0.1% of the free space in the VG
   # for docker metadata.
   _VG_SIZE=$(vgs --noheadings --nosuffix --units s -o vg_size $VG)
   _META_SIZE=$(( $_VG_SIZE / 1000 + 1 ))
-
   if [ -z "$_META_SIZE" ];then
     Fatal "Failed to calculate metadata volume size."
+  fi
+  _META_SIZE_ARG=${_META_SIZE}s
   fi
 
   if [ -n "$CHUNK_SIZE" ]; then
@@ -396,7 +400,7 @@ create_lvm_thin_pool () {
     _DATA_SIZE_ARG="-L $DATA_SIZE"
   fi
 
-  lvcreate -y --type thin-pool --zero n $_CHUNK_SIZE_ARG --poolmetadatasize ${_META_SIZE}s $_DATA_SIZE_ARG -n $CONTAINER_THINPOOL $VG
+  lvcreate -y --type thin-pool --zero n $_CHUNK_SIZE_ARG --poolmetadatasize $_META_SIZE_ARG $_DATA_SIZE_ARG -n $CONTAINER_THINPOOL $VG
 }
 
 get_configured_thin_pool() {


### PR DESCRIPTION
Right now thin pool metadata size is automatically determined. That is .1%
of free space in volume group.

A user has asked for a knob to make it configurable. They want to allocate
a larger metadata volume to start with. Looks like they run out of free space
in metadata volume and VG is full and there is not enough space to grow it
later.

Given their worklaod, they can allocate a bigger metadata volume using
this knob at the beginning.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>