### PR TITLE
Mount xfs filesystem with pquota option

### DIFF
--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -1068,7 +1068,7 @@ mount_extra_volume() {
   remove_systemd_mount_target $mount_dir
   mounts=$(extra_lv_mountpoint $vg $lv_name $mount_dir)
   if [ -z "$mounts" ]; then
-      mount /dev/$vg/$lv_name $mount_dir
+      mount -o pquota /dev/$vg/$lv_name $mount_dir
   fi
 }
 
@@ -1145,7 +1145,7 @@ Before=docker-storage-setup.service
 What=/dev/$vg/$lv_name
 Where=${mount_dir}
 Type=xfs
-Options=defaults
+Options=pquota
 
 [Install]
 WantedBy=docker-storage-setup.service


### PR DESCRIPTION
When transitioning from `devicemapper` to `overlay2`, we lose the ability to specify a disk quota for all containers ([dm.basesize](https://docs.docker.com/engine/reference/commandline/dockerd/#options-per-storage-driver)).

~~The closest analogue I've found for `overlay2` is [this feature](https://github.com/moby/moby/pull/24771), which allows a disk quota to be set per-container.
e.g. `docker run --storage-opt size=3g -it fedora /bin/bash`~~

**Update:**  I've since discovered this PR that got merged in June -- [Add overlay2.size daemon storage-opt](https://github.com/moby/moby/pull/32977) -- which allows disk quota to be specified in the `container-storage-setup` config:
```
EXTRA_STORAGE_OPTIONS="--storage-opt overlay2.size=3G"
```
--

However, it requires the XFS filesystem to be mounted with project disk quota accounting enabled (`mount -o pquota`).  `container-storage-setup` does not currently do this.

This 1st attempt is a simple but naive solution.  From what I can tell, it seems safe to assume the filesystem being mounted is XFS.  What I'm not sure about is whether there's a down side to just always enabling `pquota`.

An alternate solution might be to introduce a new mount option variable for `/etc/sysconfig/docker-storage-setup`.  Perhaps:
```
CONTAINER_ROOT_LV_MOUNT_OPTIONS=pquota
```