### PR TITLE
Switch to overlay2 as default graph driver for docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install-docker:
 	install -D -m 644 docker-storage-setup.service ${UNITDIR}/${DOCKER}-storage-setup.service
 	if [ ! -f ${SYSCONFDIR}/${DOCKER}-storage-setup ]; then \
 		install -D -m 644 docker-storage-setup-override.conf ${SYSCONFDIR}/${DOCKER}-storage-setup; \
-		echo "CONTAINER_THINPOOL=docker-pool" >> ${SYSCONFDIR}/${DOCKER}-storage-setup; \
+		echo "STORAGE_DRIVER=overlay2" >> ${SYSCONFDIR}/${DOCKER}-storage-setup; \
 	fi
 	install -d -m 755 ${BINDIR}
 	(cd ${BINDIR}; ln -sf /usr/bin/container-storage-setup ${DOCKER}-storage-setup)

--- a/container-storage-setup.1
+++ b/container-storage-setup.1
@@ -97,12 +97,6 @@ CONTAINER_THINPOOL:
       is logical volume name passed to \f[B]lvcreate\f[] when creating
       the thin pool volume.
 
-CONTAINER_THINPOOL:
-      Specify the thinpool name for the lvm thinpool. This is required
-      when using the devicemapper STORAGE_DRIVER.  CONTAINER_THINPOOL
-      is logical volume name passed to \f[B]lvcreate\f[] when creating
-      the thin pool volume.
-
 EXTRA_STORAGE_OPTIONS:
       A set of extra options that should be passed to the container
       runtime daemon.

--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -23,7 +23,7 @@ set -e
 
 # container-storage-setup version information
 _CSS_MAJOR_VERSION="0"
-_CSS_MINOR_VERSION="8"
+_CSS_MINOR_VERSION="9"
 _CSS_SUBLEVEL="0"
 _CSS_EXTRA_VERSION=""
 

--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -1367,7 +1367,8 @@ setup_storage_compat() {
 
   # If storage is configured and new driver should match old one.
   if [ -n "$current_driver" ] && [ "$current_driver" != "$STORAGE_DRIVER" ];then
-   Fatal "Storage is already configured with ${current_driver} driver. Can't configure it with ${STORAGE_DRIVER} driver. To override, remove ${_STORAGE_OUT_FILE} and retry."
+   Info "Storage is already configured with ${current_driver} driver. Can't configure it with ${STORAGE_DRIVER} driver. To override, remove ${_STORAGE_OUT_FILE} and retry."
+   return 0
   fi
 
   if [ "$STORAGE_DRIVER" == "overlay" -o "$STORAGE_DRIVER" == "overlay2" ]; then


### PR DESCRIPTION
Switch to overlay2 as default graph driver for docker. For rest, it remains unaffected.

This series adds extra checks to make sure system supports overlay2 otherwise container-storage-setup will exit with error code.

We will need to make sure that docker service has `Requires=` dependency on container-storage-setup instead of `Wants=` dependency. Otherwise docker will use loop devices which we probably don't want.