### PR TITLE
Add support for multipath devices

### DIFF
--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -733,6 +733,10 @@ is_block_dev_partition() {
     return 0
   fi
 
+  if [ "$disktype" == "mpath" ];then
+    return 1
+  fi
+
   # For loop device partitions, lsblk reports type as "loop" and not "part".
   # So check if device has a parent in the tree and if it does, there are high
   # chances it is partition (except the case of lvm volumes)


### PR DESCRIPTION
Previously, when a device-mapper multipath device was specified for DEVS
setup would fail with "Partition specification unsupported at this
time." Each device is checked to see if it has a parent, and, if so, it
is assumed to be a partition.  Multipath devices are not partitions, and
their backing paths are reported as parent devices.

This change adds the ability to correctly identify multipath devices by
checking for device type of "mpath" so that they are not mistaken for
partitions.

This should resolve [RHBZ #1496295 - container-storage-setup fails on multipath device](https://bugzilla.redhat.com/show_bug.cgi?id=1496295)