### PR TITLE
Cope with atomic upgrade overwriting /etc/sysconfig/docker-storage-setup

### DIFF
--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -614,12 +614,7 @@ setup_lvm_thin_pool_compat () {
     fi
   fi
 
-  # Enable or disable automatic pool extension
-  if [ "$AUTO_EXTEND_POOL" == "yes" ];then
-    enable_auto_pool_extension ${VG} ${thinpool_name}
-  else
-    disable_auto_pool_extension ${VG} ${thinpool_name}
-  fi
+  process_auto_pool_extenion ${VG} ${thinpool_name}
 }
 
 lvm_pool_exists() {
@@ -1079,6 +1074,16 @@ disable_auto_pool_extension() {
   rm -f ${profileDir}/${profileFile}
 }
 
+process_auto_pool_extenion() {
+  local vg=$1 thinpool_name=$2
+
+  # Enable or disable automatic pool extension
+  if [ "$AUTO_EXTEND_POOL" == "yes" ];then
+    enable_auto_pool_extension ${vg} ${thinpool_name}
+  else
+    disable_auto_pool_extension ${vg} ${thinpool_name}
+  fi
+}
 
 # Gets the current ${_STORAGE_OPTIONS}= string.
 get_current_storage_options() {
@@ -2406,12 +2411,7 @@ setup_lvm_thin_pool () {
 
   [ -n "$_STORAGE_OUT_FILE" ] &&  write_storage_config_file $STORAGE_DRIVER "$_STORAGE_OUT_FILE"
 
-  # Enable or disable automatic pool extension
-  if [ "$AUTO_EXTEND_POOL" == "yes" ];then
-    enable_auto_pool_extension ${VG} ${thinpool_name}
-  else
-    disable_auto_pool_extension ${VG} ${thinpool_name}
-  fi
+  process_auto_pool_extenion ${VG} ${thinpool_name}
 }
 
 setup_storage() {

--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -591,6 +591,12 @@ setup_lvm_thin_pool_compat () {
      if ! wait_for_dev "$tpool"; then
        Fatal "Already configured thin pool $tpool is not available. If thin pool exists and is taking longer to activate, set DEVICE_WAIT_TIMEOUT to a higher value and retry. If thin pool does not exist any more, remove ${_STORAGE_OUT_FILE} and retry"
      fi
+
+     process_auto_pool_extenion ${VG} ${thinpool_name}
+     # We found existing thin pool and waited for it and processed auto
+     # pool extension changes. There should not be any need to process
+     # further
+     return
   fi
 
   # At this point of time, a volume group should exist for lvm thin pool

--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -495,6 +495,11 @@ run_docker_compatibility_code() {
   # Verify storage options set correctly in input files
   check_storage_options
 
+  # Query and save current storage options
+  if ! _CURRENT_STORAGE_OPTIONS=$(get_current_storage_options); then
+    return 1
+  fi
+
   determine_rootfs_pvs_vg
 
   if [ $_RESET -eq 1 ]; then
@@ -1443,11 +1448,6 @@ setup_storage_compat() {
 
   if ! is_valid_storage_driver $STORAGE_DRIVER;then
     Fatal "Invalid storage driver: ${STORAGE_DRIVER}."
-  fi
-
-  # Query and save current storage options
-  if ! _CURRENT_STORAGE_OPTIONS=$(get_current_storage_options); then
-    return 1
   fi
 
   if ! current_driver=$(get_existing_storage_driver);then

--- a/container-storage-setup.sh
+++ b/container-storage-setup.sh
@@ -1457,6 +1457,7 @@ setup_storage_compat() {
   # If storage is configured and new driver should match old one.
   if [ -n "$current_driver" ] && [ "$current_driver" != "$STORAGE_DRIVER" ];then
    Info "Storage is already configured with ${current_driver} driver. Can't configure it with ${STORAGE_DRIVER} driver. To override, remove ${_STORAGE_OUT_FILE} and retry."
+   check_existing_thinpool_compat || true
    return 0
   fi
 

--- a/tests/017-test-storage-driver-change-to-overlay2-in-atomic.sh
+++ b/tests/017-test-storage-driver-change-to-overlay2-in-atomic.sh
@@ -1,0 +1,66 @@
+source $SRCDIR/libtest.sh
+
+# We recently changed default storage driver to overlay2. That change
+# takes affect only over fresh installation and not over upgrade. But
+# in atomic, even over upgrade it overwrites existing
+# /etc/sysconfig/docker-storage-setup file and after upgrade and reboot
+# we don't wait for thin pool as we exit early thinking storage driver
+# changed.
+
+# Make sure, even if storage driver changed, we try to bring up existing
+# thin pool.
+test_storage_driver_change() {
+  local devs=$TEST_DEVS
+  local test_status=1
+  local testname=`basename "$0"`
+  local vg_name="css-test-foo"
+
+  # Error out if any pre-existing volume group vg named css-test-foo
+  if vg_exists "$vg_name"; then
+    echo "ERROR: $testname: Volume group $vg_name already exists." >> $LOGS
+    return $test_status
+  fi
+
+  # Create config file
+  cat << EOF > /etc/sysconfig/docker-storage-setup
+DEVS="$devs"
+VG=$vg_name
+EOF
+
+ # Run container-storage-setup
+ $CSSBIN >> $LOGS 2>&1
+
+ # Test failed.
+ if [ $? -ne 0 ]; then
+    echo "ERROR: $testname: $CSSBIN failed." >> $LOGS
+    cleanup $vg_name "$devs"
+    return $test_status
+ fi
+
+  # Make sure volume group $VG got created
+  if ! vg_exists "$vg_name"; then
+    echo "ERROR: $testname: $CSSBIN failed. $vg_name was not created." >> $LOGS
+    cleanup $vg_name "$devs"
+    return $test_status
+  fi
+
+  # Overwrite config file
+  cat << EOF > /etc/sysconfig/docker-storage-setup
+STORAGE_DRIVER=overlay2
+EOF
+  # Run container-storage-setup
+  $CSSBIN >> $LOGS 2>&1
+
+  # Test failed.
+  if [ $? -ne 0 ]; then
+    echo "ERROR: $testname: $CSSBIN failed." >> $LOGS
+  else
+    test_status=0
+  fi
+
+  cleanup $vg_name "$devs"
+  return $test_status
+}
+
+test_storage_driver_change
+

--- a/tests/018-test-thinpool-reset-after-driver-change-to-overlay2-in-atomic.sh
+++ b/tests/018-test-thinpool-reset-after-driver-change-to-overlay2-in-atomic.sh
@@ -1,0 +1,74 @@
+source $SRCDIR/libtest.sh
+
+# We recently changed default storage driver to overlay2. That change
+# takes affect only over fresh installation and not over upgrade. But
+# in atomic, even over upgrade it overwrites existing
+# /etc/sysconfig/docker-storage-setup file and after upgrade storage reset
+# does not reset thin pool thinking storage driver is not devicemapper.
+
+# Make sure thinpool can be reset even after atomic upgrade.
+test_storage_driver_reset() {
+  local devs=$TEST_DEVS
+  local test_status=1
+  local testname=`basename "$0"`
+  local vg_name="css-test-foo"
+
+  # Error out if any pre-existing volume group vg named css-test-foo
+  if vg_exists "$vg_name"; then
+    echo "ERROR: $testname: Volume group $vg_name already exists." >> $LOGS
+    return $test_status
+  fi
+
+  # Create config file
+  cat << EOF > /etc/sysconfig/docker-storage-setup
+DEVS="$devs"
+VG=$vg_name
+EOF
+
+ # Run container-storage-setup
+ $CSSBIN >> $LOGS 2>&1
+
+ # Test failed.
+ if [ $? -ne 0 ]; then
+    echo "ERROR: $testname: $CSSBIN failed." >> $LOGS
+    cleanup $vg_name "$devs"
+    return $test_status
+ fi
+
+  # Make sure volume group $VG got created
+  if ! vg_exists "$vg_name"; then
+    echo "ERROR: $testname: $CSSBIN failed. $vg_name was not created." >> $LOGS
+    cleanup $vg_name "$devs"
+    return $test_status
+  fi
+
+  # Overwrite config file
+  cat << EOF > /etc/sysconfig/docker-storage-setup
+STORAGE_DRIVER=overlay2
+EOF
+  # Reset storage
+  $CSSBIN --reset >> $LOGS 2>&1
+
+  # Test failed.
+  if [ $? -eq 0 ]; then
+     if [ -e /etc/sysconfig/docker-storage ]; then
+         echo "ERROR: $testname: $CSSBIN failed. /etc/sysconfig/docker-storage still exists." >> $LOGS
+     else
+         if lv_exists $vg_name "docker-pool"; then
+             echo "ERROR: $testname: Thin pool docker-pool still exists." >> $LOGS
+         else
+             test_status=0
+         fi
+     fi
+  fi
+
+  if [ $test_status -ne 0 ]; then
+      echo "ERROR: $testname: $CSSBIN --reset failed." >> $LOGS
+  fi
+
+  cleanup $vg_name "$devs"
+  return $test_status
+}
+
+test_storage_driver_reset
+


### PR DESCRIPTION
Our current default driver is "devicemapper" and recently it was changed to "overlay2". Normally it works as over upgrades rpms don't overwrite /etc/sysconfig/docker-storage-setup. (It is not a config(noreplace) file). 

But atomic does not understand it and overwrites this file over upgrade. That means we are left with a scenario where a devicemapper thin pool is already configured but /etc/sysconfig/docker-storage-setup
has STORAGE_DRIVER=overlay2.

This is a corner case. Deal with it. During start, bring up thin pool if one is already configured. And during reset, continue to reset if there is a configured thin pool.